### PR TITLE
after_configuration sets scope to app instance automatically

### DIFF
--- a/lib/middleman/ember/extension.rb
+++ b/lib/middleman/ember/extension.rb
@@ -12,7 +12,7 @@ module Middleman
 
         app.after_configuration do
           ember_version = 
-            if app.ember_variant == :production
+            if ember_variant == :production
               "prod."
             else
               ""


### PR DESCRIPTION
Having the `app.` uses an out-of-date, pre-config parsing version of the app.
