### PR TITLE
Require dependencies before using them.

### DIFF
--- a/lib/middleman/ember/extension.rb
+++ b/lib/middleman/ember/extension.rb
@@ -1,5 +1,13 @@
 require 'middleman-core'
 
+require 'ember/source'
+require 'handlebars/source'
+begin
+  require 'ember/data/source'
+rescue LoadError
+  # ember-data was not installed.
+end
+
 module Middleman
   module Ember
     class << self


### PR DESCRIPTION
This change `require`s the main files of the gems that `middleman-ember` depends on before referencing constants defined in those files, so gems are always loaded in the correct order.

The `require` sequence correctly reflects the fact that `ember-source` is a required dependency, but `ember-data-source` is an optional one.

Thank you very much for packaging ember.js for use with middleman! Please consider merging this change, to make the integration a tiny bit easier.
